### PR TITLE
Remove demeaning descriptors

### DIFF
--- a/template/base.html.twig
+++ b/template/base.html.twig
@@ -6,7 +6,7 @@
         <link href="//netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
         <link rel="stylesheet" type="text/css" href="/skin/css/tooltipster.css" />
 
-        <title>MageHero | Magento Developers</title>
+        <title>MageHero | Magento Heroes</title>
         <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
         <script type="text/javascript" src="/js/jquery.tooltipster.js"></script>
         <script type="text/javascript" src="/js/app.js"></script>
@@ -26,7 +26,7 @@
     {% block masthead %}
         <div class="masthead">
             <h1><a href="/">MageHero</a></h1>
-            <p>Magento Developers</p>
+            <p>Magento Heroes</p>
         </div>
     {% endblock %}
 


### PR DESCRIPTION
Removed "Ninjas, Rockstars, and Samurais" in place of Developer as I'm fairly certain very few people on the list are actually trained Ninjas or Samurais and while some might be in bands they are most certainly not rock stars (I mean, if they are, why are they still writing code?)

In the future, please don't encourage idiot recruiters/hiring managers that use these terms. You might be trying to be funny, but it has been my experience that those same recruiters/hiring managers lack the ability to understand tongue-in-cheek jokes and will instead infer that we like those terms. 
