### PR TITLE
Simple Validation to Prevent XSS

### DIFF
--- a/code/Model/User.php
+++ b/code/Model/User.php
@@ -168,7 +168,7 @@ class Model_User
 
     protected function validateDetails($json)
     {
-        $data = json_decode($json);
+        $data = json_decode($json, true);
         foreach ($this->_validationPatterns as $key => $pattern) {
             if (!isset($data[$key])) {
                 continue;


### PR DESCRIPTION
In its current form you can inject `javascript:` and presumably `data:` urls in most of the JSON url fields. The below validation proposal, while simple, should prevent at least vectors involving invalid urls in the StackOverflow or Magento Certification fields.

Updated to allow a few different forms of StackExchange url.
