### PR TITLE
Improve login code so that it can be included more easily on controllers including being able to maintain referring page URL.

### DIFF
--- a/code/Controller/Abstract.php
+++ b/code/Controller/Abstract.php
@@ -2,13 +2,57 @@
 
 class Controller_Abstract
 {
+    CONST SESSION_NAMESPACE = "magedev";
+
     protected $_container;
     protected $_currentUser;
 
+    protected function _preDispatch()
+    {
+
+    }
+
+    /**
+     * @param null $path
+     * @param null $params
+     */
+    protected function _redirect($path = null, $params = null)
+    {
+        // If internal URL, ensure to include base URL
+        if (strpos($path, 'http') === false) {
+            $path = self::_getConfigData('base_url') . '/' . $path;
+        }
+
+        // Redirect with GET parameters
+        if (isset($params)) {
+            $path .= '?' . http_build_query($params);
+        }
+
+        header('Location: ' . $path);
+        exit;
+    }
+
+    /**
+     * @param $key
+     * @param $value
+     */
+    protected function _setSession($key, $value)
+    {
+        $_SESSION[self::SESSION_NAMESPACE][$key] = $value;
+    }
+
     protected function _getSession()
     {
-        $session = isset($_SESSION['magedevs']) ? $_SESSION['magedevs'] : array();
+        $session = isset($_SESSION[self::SESSION_NAMESPACE]) ? $_SESSION[self::SESSION_NAMESPACE] : array();
         return $session;
+    }
+
+    /**
+     * @param $username
+     */
+    protected function _setUsername($username)
+    {
+        $this->_setSession('github_username', $username);
     }
 
     protected function _getUsername()

--- a/code/Controller/Account.php
+++ b/code/Controller/Account.php
@@ -1,0 +1,66 @@
+<?php
+
+require_once dirname(dirname(dirname(__FILE__))) . '/vendor/lusitanian/oauth/src/OAuth/bootstrap.php';
+
+use OAuth\OAuth2\Service\GitHub;
+use OAuth\Common\Storage\Session;
+use OAuth\Common\Consumer\Credentials;
+
+class Controller_Account extends Controller_Abstract
+{
+
+    protected function _preDispatch()
+    {
+
+        // Return if already logged in
+        if ($this->_getUsername())
+            return;
+
+        // This was a callback request from github, get the token
+        if (!empty($_GET['code'])) {
+            $github = $this->_getGithubService();
+
+            $github->requestAccessToken($_GET['code']);
+
+            $result = json_decode($github->request('user'), true);
+            if (!isset($result['login'])) {
+                throw new Exception("Couldn't get github username");
+            }
+
+            $this->_setUsername($result['login']);
+            $this->_setSession('image_url', $result['avatar_url']);
+
+        // Forward on to github to login
+        } else {
+            $github = $this->_getGithubService($this->_getConfigData('base_url') . $_SERVER['REQUEST_URI']);
+            $url = $github->getAuthorizationUri();
+
+            header('Location: ' . $url);
+            exit;
+        }
+    }
+
+    /**
+     *
+     * @param call
+     * @return \OAuth\OAuth2\Service\GitHub
+     */
+    protected function _getGithubService($callbackUrl = null)
+    {
+        // Session storage
+        $storage = new Session();
+        $serviceFactory = new \OAuth\ServiceFactory();
+
+        if (is_null($callbackUrl)) {
+            $callbackUrl = $this->_getConfigData('base_url') . "/login/";
+        }
+
+        $apiKey = $this->_getConfigData('github_api_key');
+        $apiSecret = $this->_getConfigData('github_api_secret');
+
+        $credentials = new Credentials($apiKey, $apiSecret, $callbackUrl);
+        $github = $serviceFactory->createService('GitHub', $credentials, $storage, array('user:email'));
+
+        return $github;
+    }
+}

--- a/code/Controller/Login.php
+++ b/code/Controller/Login.php
@@ -2,52 +2,18 @@
 
 require_once dirname(dirname(dirname(__FILE__))) . '/vendor/lusitanian/oauth/src/OAuth/bootstrap.php';
 
-use OAuth\OAuth2\Service\GitHub;
-use OAuth\Common\Storage\Session;
-use OAuth\Common\Consumer\Credentials;
-
-class Controller_Login extends Controller_Abstract
+class Controller_Login extends Controller_Account
 {
-    public function get()
+
+    protected function _preDispatch()
     {
-        $github = $this->_getGithubService();
-
-        if (!empty($_GET['code'])) {
-            // This was a callback request from github, get the token
-            $github->requestAccessToken($_GET['code']);
-
-            $result = json_decode($github->request('user'), true);
-            if (!isset($result['login'])) {
-                throw new Exception("Couldn't get github username");
-            }
-
-            $username = isset($result['login']) ? $result['login'] : null;
-            $_SESSION['magedevs']['github_username'] = $username;
-            $_SESSION['magedevs']['image_url'] = isset($result['avatar_url']) ? $result['avatar_url'] : null;
-
-            header("location: /");
-        } else {
-            $url = $github->getAuthorizationUri();
-            header('Location: ' . $url);
-        }
+        parent::_preDispatch();
     }
 
-    /**
-     * @return \OAuth\OAuth2\Service\GitHub
-     */
-    protected function _getGithubService()
+    public function get()
     {
-        // Session storage
-        $storage = new Session();
-        $serviceFactory = new \OAuth\ServiceFactory();
+        $this->_preDispatch();
 
-        $url = $this->_getConfigData('base_url') . "/login/";
-        $apiKey = $this->_getConfigData('github_api_key');
-        $apiSecret = $this->_getConfigData('github_api_secret');
-
-        $credentials = new Credentials($apiKey, $apiSecret, $url);
-        $github = $serviceFactory->createService('GitHub', $credentials, $storage, array('user:email'));
-
-        return $github;
+        $this->_redirect($_SERVER['HTTP_REFERER']);
     }
 }

--- a/code/Controller/PostEdit.php
+++ b/code/Controller/PostEdit.php
@@ -1,10 +1,22 @@
 <?php
 
-class Controller_PostEdit extends Controller_Abstract
+class Controller_PostEdit extends Controller_Account
 {
+    public function _preDispatch()
+    {
+        parent::_preDispatch();
+    }
+
+
     public function get($postId)
     {
+        $this->_preDispatch();
+
         $post = $this->_getContainer()->Post()->load($postId);
+        if ($this->_getCurrentUser()->getId() != $post->getUserId()) {
+            die("Permission denied");
+        }
+
         $tags = $this->_getContainer()->Tag()->fetchAll();
 
         echo $this->_getTwig()->render('post_edit.html.twig', array(
@@ -46,7 +58,7 @@ class Controller_PostEdit extends Controller_Abstract
             ->set('image_url', $imageUrl)
             ->save();
 
-        header("Location: " . $post->getUrl());
+        $this->_redirect($post->getUrl());
     }
 
 }

--- a/code/Controller/PostNew.php
+++ b/code/Controller/PostNew.php
@@ -1,17 +1,21 @@
 <?php
 
-class Controller_PostNew extends Controller_Abstract
+class Controller_PostNew extends Controller_Account
 {
-    public function get()
+    protected function _preDispatch()
     {
-        if (! $this->_getUsername()) {
-            die("You have to login first");
-        }
+        parent::_preDispatch();
 
         $minimumVoteCount = $this->_getContainer()->LocalConfig()->getPostingMinimumVotecount();
         if ($this->_getCurrentUser()->getVoteCount() < $minimumVoteCount) {
             die("You have to have $minimumVoteCount vote(s) in order to post");
         }
+    }
+
+
+    public function get()
+    {
+        $this->_preDispatch();
 
         $data = array(
             "subject"   => "New Post",
@@ -22,7 +26,6 @@ class Controller_PostNew extends Controller_Abstract
         $post = $this->_getContainer()->Post()->setData($data)->save();
         $postId = $post->getId();
 
-        header("location: /posts/$postId/edit");
-        exit;
+        $this->_redirect("posts/$postId/edit");
     }
 }


### PR DESCRIPTION

- Migrate from Login to account controller
- Add predispatch suggestion to all controllers
- Move github login to predispatch for those account related controllers that need it
- Pass in referring URL so that we can redirect back to the correct page post login, e.g click on "What are you working on when logged out" and it will redirect you to the edit post page after login. Similarly when on post as a logged out user and you click login, redirect to the post rather than the homepage.
- Add some more security using predispatch on edit post controller so that you cannot view the edit form
- Added redirect helper