### PR TITLE
Remove minimum vote commitment for new posts

### DIFF
--- a/code/Controller/PostNew.php
+++ b/code/Controller/PostNew.php
@@ -5,11 +5,6 @@ class Controller_PostNew extends Controller_Account
     protected function _preDispatch()
     {
         parent::_preDispatch();
-
-        $minimumVoteCount = $this->_getContainer()->LocalConfig()->getPostingMinimumVotecount();
-        if ($this->_getCurrentUser()->getVoteCount() < $minimumVoteCount) {
-            die("You have to have $minimumVoteCount vote(s) in order to post");
-        }
     }
 
 


### PR DESCRIPTION
We used to require users to have a minimum number of votes to be able to create new posts. This doesn't make sense now that ratings are based on posts!