### PR TITLE
Use Slugless URLs as GUID in Feed

### DIFF
--- a/code/Model/Post.php
+++ b/code/Model/Post.php
@@ -276,6 +276,11 @@ class Model_Post extends Model_Record
         $url = implode("/", array($this->_localConfig->get('base_url'), "posts", $this->getId(), $this->getSlug()));
         return $url;
     }
+    
+    public function getSluglessUrl()
+    {
+        return implode("/", array($this->_localConfig->get('base_url'), "posts", $this->getId()));
+    }
 
     public function getEditUrl()
     {

--- a/template/feed.xml.twig
+++ b/template/feed.xml.twig
@@ -24,7 +24,7 @@
           <link>{{ post.getUrl() }}</link>
           <pubDate>{{ post.getCreatedAt()|date("D, d M Y H:i:s O") }}</pubDate>
           <dc:creator>{{ post.get('name') }}</dc:creator>
-          <guid>{{ post.getUrl() }}</guid>
+          <guid>{{ post.getSluglessUrl() }}</guid>
           <description>{{ post.getBodyAsHtml() }}</description>
         </item>
         {% endfor %}


### PR DESCRIPTION
This PR removes the slug from the URLs used in the RSS feed's GUID field.

The purpose of this is to prevent posts from being shown as "new" when only the title has changed. (For typos, etc.)

A downside of merging this change is that all posts in the feed will show up as unread again, but this is a one-time downside.

**WARNING**: I did not test this code as I'm knee deep in applying Magento patches.